### PR TITLE
Fix near frame tap detection at HFR.

### DIFF
--- a/src/input.h
+++ b/src/input.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <chrono>
 #include <stdint.h>
 #include "diva.h"
 
@@ -44,24 +45,18 @@ enum Stick : int32_t
 
 struct ButtonState
 {
-	static constexpr size_t MaxKeepStates = 32;
-
 	struct StateData
 	{
-		bool down;
-		bool up;
-		bool tapped;
-		bool released;
-	} data[MaxKeepStates];
+		bool down{};
+		bool up{};
+		bool tapped{};
+		bool released{};
+		std::chrono::steady_clock::time_point time;
+	};
 
-	inline StateData& Push()
-	{
-		for (int32_t i = MaxKeepStates - 2; i >= 0; i--)
-			data[i + 1] = data[i];
+	std::vector<StateData> data;
 
-		memset(&data[0], 0, sizeof(StateData));
-		return data[0];
-	}
+	StateData& Push(const std::chrono::steady_clock::time_point& time);
 	
 	inline bool IsDown() const { return data[0].down; }
 	inline bool IsTapped() const { return data[0].tapped; }
@@ -99,7 +94,7 @@ struct MacroState
 	}
 
 	bool Update(void* internal_handler, int32_t player_index);
-	void UpdateSticks(diva::InputState* input_state);
+	void UpdateSticks(diva::InputState* input_state, const std::chrono::steady_clock::time_point& time);
 	bool GetStarHit() const;
 	bool GetDoubleStarHit() const;
 	bool GetStarHitCancel() const;


### PR DESCRIPTION
Hey there, wanted to try fixing this myself and to give you an idea how it could be done. I'm marking this as draft right now for the following reasons:
- At 60 FPS, 3 frames are accounted for, so what is the timing here exactly? 16.66ms x 3 or 16.66ms x 2? What do the console games do?
- The container is a std::vector now instead of a fixed size array, and we are constantly pushing new elements to the front, which can potentially be expensive. Maybe a different container type could be used here?
- Similarly, we are constantly removing old states from the end, though this is very very cheap for std::vector.
- We are using steady_clock here, which depends on the CPU clock speeds. Does the game have its own simulation time? It might be a better idea to use that instead if it's a global variable somewhere.

I'd like to hear your thoughts here on how to implement this. So far from my tests, it works perfectly fine at 360 FPS though.